### PR TITLE
Added documentation for lib/gridfs

### DIFF
--- a/lib/mongodb/gridfs/chunk.js
+++ b/lib/mongodb/gridfs/chunk.js
@@ -1,6 +1,21 @@
 var BinaryParser = require('../bson/binary_parser').BinaryParser,
   sys = require('sys');
 
+/**
+ * Class for representing a signle chunk in GridFS.
+ *
+ * @class
+ *
+ * @param file {GridStore} The {@link GridStore} object holding this chunk.
+ * @param mongoObject {object} The mongo object representation of this chunk.
+ *
+ * @throws Error when the type of data field for {@link mongoObject} is not
+ *     supported. Currently supported types for data field are instances of
+ *     {@link String}, {@link Array}, {@link Binary} and {@link Binary}
+ *     from the bson module
+ *
+ * @see Chunk#buildMongoObject
+ */
 var Chunk = exports.Chunk = function(file, mongoObject) {
   this.file = file;
   var mongoObjectFinal = mongoObject == null ? {} : mongoObject;
@@ -24,17 +39,38 @@ var Chunk = exports.Chunk = function(file, mongoObject) {
   }
   // Update position
   this.internalPosition = 0;
-  // Getters and Setters
+	/**
+	 * The position of the read/write head
+	 * @name position
+	 * @lends Chunk#
+	 * @field
+	 */
   this.__defineGetter__("position", function() { return this.internalPosition; });
   this.__defineSetter__("position", function(value) { this.internalPosition = value; });
 };
 
+/**
+ * Writes a data to this object and advance the read/write head.
+ *
+ * @param data {string} the data to write 
+ * @param callback {function(*, GridStore)} This will be called after executing
+ *     this method. The first parameter will contain null and the second one
+ *     will contain a reference to this object.
+ */
 Chunk.prototype.write = function(data, callback) {
   this.data.write(data, this.internalPosition);
   this.internalPosition = this.data.length();
   callback(null, this);
 };
 
+/**
+ * Reads data and advances the read/write head.
+ *
+ * @param length {number} The length of data to read.
+ *
+ * @return {string} The data read if the given length will not exceed the end of
+ *     the chunk. Returns an empty String otherwise.
+ */
 Chunk.prototype.read = function(length) {  
   if(this.length() - this.internalPosition + 1 >= length) {
     var data = this.data.read(this.internalPosition, length);
@@ -45,19 +81,44 @@ Chunk.prototype.read = function(length) {
   }
 };
 
+/**
+ * Checks if the read/write head is at the end.
+ *
+ * @return {boolean} Whether the read/write head has reached the end of this
+ *     chunk.
+ */
 Chunk.prototype.eof = function() {
   return this.internalPosition == this.length() ? true : false;
 };
 
+/**
+ * Reads one character from the data of this chunk and advances the read/write
+ * head.
+ *
+ * @return {string} a single character data read if the the read/write head is
+ *     not at the end of the chunk. Returns an empty String otherwise.
+ */
 Chunk.prototype.getc = function() {
   return this.read(1);
 };
 
+/**
+ * Clears the contents of the data in this chunk and resets the read/write head
+ * to the initial position.
+ */
 Chunk.prototype.rewind = function() {
   this.internalPosition = 0;
   this.data = new this.file.db.bson_serializer.Binary();
 };
 
+/**
+ * Saves this chunk to the database. Also overwrites existing entries having the
+ * same id as this chunk.
+ *
+ * @param callback {function(*, GridStore)} This will be called after executing
+ *     this method. The first parameter will contain null and the second one
+ *     will contain a reference to this object.
+ */
 Chunk.prototype.save = function(callback) {
   var self = this;
 
@@ -76,6 +137,24 @@ Chunk.prototype.save = function(callback) {
   });
 };
 
+/**
+ * Creates a mongoDB object representation of this chunk.
+ *
+ * @param callback {function(Object)} This will be called after executing this 
+ *     method. The object will be passed to the first parameter and will have
+ *     the structure:
+ *        
+ *        <pre><code>
+ *        {
+ *          '_id' : , // {number} id for this chunk
+ *          'files_id' : , // {number} foreign key to the file collection
+ *          'n' : , // {number} chunk number
+ *          'data' : , // {bson#Binary} the chunk data itself
+ *        }
+ *        </code></pre>
+ *
+ * @see <a href="http://www.mongodb.org/display/DOCS/GridFS+Specification#GridFSSpecification-{{chunks}}">MongoDB GridFS Chunk Object Structure</a>
+ */
 Chunk.prototype.buildMongoObject = function(callback) {
   var mongoObject = {'_id': this.objectId,
     'files_id': this.file.fileId,
@@ -84,8 +163,15 @@ Chunk.prototype.buildMongoObject = function(callback) {
   callback(mongoObject);
 };
 
+/**
+ * @return {number} the length of the data
+ */
 Chunk.prototype.length = function() {
   return this.data.length();
 };
 
+/**
+ * The default chunk size
+ * @constant
+ */
 Chunk.DEFAULT_CHUNK_SIZE = 1024 * 256;

--- a/lib/mongodb/gridfs/gridstore.js
+++ b/lib/mongodb/gridfs/gridstore.js
@@ -1,3 +1,12 @@
+/**
+ * @fileOverview GridFS is a tool for MongoDB to store files to the database.
+ * Because of the restrictions of the object size the database can hold, a
+ * facility to split a file into several chunks is needed. The {@link GridStore}
+ * class offers a simplified api to interact with files while managing the
+ * chunks of split files behind the scenes. More information about GridFS can be
+ * found <a href="http://www.mongodb.org/display/DOCS/GridFS">here</a>.
+ */
+
 var BinaryParser = require('../bson/binary_parser').BinaryParser,
   Chunk = require('./chunk').Chunk,
   DbCommand = require('../commands/db_command').DbCommand,
@@ -6,6 +15,33 @@ var BinaryParser = require('../bson/binary_parser').BinaryParser,
   Buffer = require('buffer').Buffer,
   fs = require('fs');
 
+/**
+ * A class representation of a file stored in GridFS.
+ *
+ * @class
+ *
+ * @param db {Db} A database instance to interact with.
+ * @param filename {string} The name for the file.
+ * @param mode {?string} Set the mode for this file. Available modes:
+ *     <ul>
+ *       <li>"r" - read only. This is the default mode.</li>
+ *       <li>"w" - write in truncate mode. Existing data will be overwriten</li>
+ *       <li>"w+" - write in edit mode.</li>
+ *     </ul>
+
+ * @param options {?object} Optional properties to specify. Recognized keys:
+ *
+ *     <pre><code>
+ *     {
+ *       'root' : , // {string} root collection to use. Defaults to GridStore#DEFAULT_ROOT_COLLECTION
+ *       'chunk_type' : , // {string} mime type of the file. Defaults to GridStore#DEFAULT_CONTENT_TYPE
+ *       'chunk_size' : , // {number} size for the chunk. Defaults to Chunk#DEFAULT_CHUNK_SIZE.
+ *       'metadata' : , // {object} arbitrary data the user wants to store
+ *     }
+ *     </code></pre>
+ *
+ * @see <a href="http://www.mongodb.org/display/DOCS/GridFS+Specification">MongoDB GridFS Specification</a>
+ */
 var GridStore = exports.GridStore = function(db, filename, mode, options) {
   this.db = db;
   this.filename = filename;
@@ -13,7 +49,14 @@ var GridStore = exports.GridStore = function(db, filename, mode, options) {
   this.options = options == null ? {} : options;
   this.root = this.options['root'] == null ? exports.GridStore.DEFAULT_ROOT_COLLECTION : this.options['root'];
   this.position = 0;
-  // Getters and Setters
+
+	/**
+	 * The chunk size used by this file.
+	 *
+	 * @name chunkSize
+	 * @lends GridStore
+	 * @field
+	 */
   this.__defineGetter__("chunkSize", function() { return this.internalChunkSize; });
   this.__defineSetter__("chunkSize", function(value) {
     if(!(this.mode[0] == "w" && this.position == 0 && this.uploadDate == null)) {
@@ -22,10 +65,28 @@ var GridStore = exports.GridStore = function(db, filename, mode, options) {
       this.internalChunkSize = value;
     }
   });
+
+	/**
+	 * The md5 checksum for this file.
+	 *
+	 * @name md5
+	 * @lends GridStore
+	 * @field
+	 */
   this.__defineGetter__("md5", function() { return this.internalMd5; });
   this.__defineSetter__("md5", function(value) {});
 };
 
+/**
+ * Opens the file from the database and initialize this object. Also creates a
+ * new one if file does not exist.
+ *
+ * @param callback {function(?Error, ?GridStore)} This will be called after 
+ *     executing this method. The first parameter will contain an {@link Error}
+ *     object and the second parameter will be null if an error occured.
+ *     Otherwise, the first parameter will be null and the second will contain
+ *     the reference to this object.
+ */
 GridStore.prototype.open = function(callback) {
   var self = this;
 
@@ -98,6 +159,16 @@ GridStore.prototype.open = function(callback) {
   });
 };
 
+/**
+ * Stores a file from the file system to the GridFS database.
+ *
+ * @param file {string|fd} The file to store.
+ * @param callback {function(*, GridStore)} This will be called after this
+ *     method is executed. The first parameter will be null and the the
+ *     second will contain the reference to this object.
+ *
+ * @see GridStore#write
+ */
 GridStore.prototype.writeFile = function (file, callback) {
   var self = this;
   if (typeof file === 'string') {
@@ -135,6 +206,19 @@ GridStore.prototype.writeFile = function (file, callback) {
 
 };
 
+/**
+ * Writes some data. This method will work properly only if initialized with mode
+ * "w" or "w+".
+ *
+ * @param string {string} The data to write.
+ * @param close {boolean=false} opt_argument Closes this file after writing if
+ *     true.
+ * @param callback {function(*, GridStore)} This will be called after executing
+ *     this method. The first parameter will contain null and the second one
+ *     will contain a reference to this object.
+ *
+ * @see GridStore#writeFile
+ */
 GridStore.prototype.write = function(string, close, callback) {
   if(typeof close === "function") { callback = close; close = null; }
   var self = this;
@@ -183,6 +267,28 @@ GridStore.prototype.write = function(string, close, callback) {
   }
 };
 
+/**
+ * Creates a mongoDB object representation of this object.
+ *
+ * @param callback {function(object)} This will be called after executing this
+ *     method. The object will be passed to the first parameter and will have
+ *     the structure:
+ *        
+ *        <pre><code>
+ *        {
+ *          '_id' : , // {number} id for this file
+ *          'filename' : , // {string} name for this file
+ *          'contentType' : , // {string} mime type for this file
+ *          'length' : , // {number} size of this file?
+ *          'chunksize' : , // {number} chunk size used by this file
+ *          'uploadDate' : , // {Date}
+ *          'aliases' : , // {array of string}
+ *          'metadata' : , // {string}
+ *        }
+ *        </code></pre>
+ *
+ * @see <a href="http://www.mongodb.org/display/DOCS/GridFS+Specification#GridFSSpecification-{{files}}">MongoDB GridFS File Object Structure</a>
+ */
 GridStore.prototype.buildMongoObject = function(callback) {
   var length = this.currentChunk != null ? (this.currentChunk.chunkNumber * this.chunkSize + this.currentChunk.position) : 0;
   var mongoObject = {
@@ -203,6 +309,16 @@ GridStore.prototype.buildMongoObject = function(callback) {
   });
 };
 
+/**
+ * Saves this file to the database. This will overwrite the old entry if it
+ * already exists. This will work properly only if mode was initialized to
+ * "w" or "w+".
+ *
+ * @param callback {function(?Error, GridStore)} This will be called after
+ *     executing this method. Passes an {@link Error} object to the first
+ *     parameter and null to the second if an error occured. Otherwise, passes
+ *     null to the first and a reference to this object to the second.
+ */
 GridStore.prototype.close = function(callback) {
   var self = this;
 
@@ -244,6 +360,17 @@ GridStore.prototype.close = function(callback) {
   }
 };
 
+/**
+ * Gets the nth chunk of this file.
+ *
+ * @param chunkNumber {number} The nth chunk to retrieve.
+ * @param callback {function(*, Chunk|object)} This will be called after
+ *     executing this method. null will be passed to the first parameter while
+ *     a new {@link Chunk} instance will be passed to the second parameter if
+ *     the chunk was found or an empty object {} if not.
+ *
+ * @see GridStore#lastChunkNumber
+ */
 GridStore.prototype.nthChunk = function(chunkNumber, callback) {
   var self = this;
 
@@ -257,14 +384,39 @@ GridStore.prototype.nthChunk = function(chunkNumber, callback) {
   });
 };
 
+/**
+ * @return {number} The last chunk number of this file.
+ *
+ * @see GridStore#nthChunk
+ */
 GridStore.prototype.lastChunkNumber = function() {
   return this.db.bson_serializer.BSON.toInt((this.length/this.chunkSize));
 };
 
+/**
+ * Retrieve this file's chunks collection.
+ *
+ * @param callback {function(?Error, ?Collection)} This will be called after
+ *     executing this method. An exception object will be passed to the first 
+ *     parameter when an error occured or null otherwise. A new
+ *     {@link Collection} object will be passed to the second parameter if no
+ *     error occured.
+ *
+ * @see Db#collection
+ * @see GridStore#collection
+ */
 GridStore.prototype.chunkCollection = function(callback) {
   this.db.collection((this.root + ".chunks"), callback);
 };
 
+/**
+ * Deletes all the chunks of this file in the database.
+ *
+ * @param callback {function(*, boolean)} This will be called after this method
+ *     executes. Passes null to the first and true to the second argument.
+ *
+ * @see GridStore#rewind
+ */
 GridStore.prototype.deleteChunks = function(callback) {
   var self = this;
 
@@ -279,12 +431,37 @@ GridStore.prototype.deleteChunks = function(callback) {
   }
 };
 
+/**
+ * Retrieves the file collection associated with this object.
+ *
+ * @param callback {function(?Error, ?Collection)} This will be called after
+ *     executing this method. An exception object will be passed to the first 
+ *     parameter when an error occured or null otherwise. A new
+ *     {@link Collection} object will be passed to the second parameter if no
+ *     error occured.
+ *
+ * @see Db#collection
+ * @see GridStore#chunkCollection
+ */
 GridStore.prototype.collection = function(callback) {
   this.db.collection(this.root + ".files", function(err, collection) {
     callback(err, collection);
   });
 };
 
+/**
+ * Reads the data of this file.
+ *
+ * @param separator {string=null} opt_argument The character to be recognized as
+ *     the newline separator.
+ * @param callback {function(*, Array<string>)} This will be called after this
+ *     method is executed. The first parameter will be null and the second
+ *     parameter will contain an array of strings representing the entire data,
+ *     each element representing a line including the separator character.
+ *
+ * @see GridStore#read
+ * @see GridStore#eof
+ */
 GridStore.prototype.readlines = function(separator, callback) {
   var args = Array.prototype.slice.call(arguments, 0);
   callback = args.pop();
@@ -300,6 +477,16 @@ GridStore.prototype.readlines = function(separator, callback) {
   });
 };
 
+/**
+ * Deletes all the chunks of this file in the database if mode was set to "w" or
+ * "w+" and resets the read/write head to the initial position.
+ *
+ * @param callback {function(*, GridStore)} This will be called after executing
+ *     this method. The first parameter will contain null and the second one
+ *     will contain a reference to this object.
+ *
+ * @see GridStore#deleteChunks
+ */
 GridStore.prototype.rewind = function(callback) {
   var self = this;
 
@@ -325,6 +512,28 @@ GridStore.prototype.rewind = function(callback) {
   }
 };
 
+/**
+ * Retrieves the contents of this file and advances the read/write head.
+ *
+ * There are 3 signatures for this method:
+ *
+ * (callback)
+ * (length, callback)
+ * (length, buffer, callback)
+ *
+ * @param length {number=} opt_argument The number of characters to read. Reads
+ *     all the characters from the read/write head to the EOF if not specified.
+ * @param buffer {string=''} opt_argument A string to hold temporary data. This
+ *     is used for storing the string data read so far when recursively calling
+ *     this method.
+ * @param callback {function(*, string)} This will be called after this method
+ *     is executed. null will be passed to the first parameter and a string 
+ *     containing the contents of the buffer concatenated with the contents read
+ *     from this file will be passed to the second.
+ *
+ * @see GridStore#readlines
+ * @see GridStore#eof
+ */
 GridStore.prototype.read = function(length, buffer, callback) {
   var self = this;
 
@@ -354,10 +563,41 @@ GridStore.prototype.read = function(length, buffer, callback) {
   }
 };
 
+/**
+ * Retrieves the position of the read/write head of this file.
+ *
+ * @param callback {function(*, number)} This gets called after this method
+ *     terminates. null is passed to the first parameter and the position is
+ *     passed to the second.
+ *
+ * @see GridStore#seek
+ */
 GridStore.prototype.tell = function(callback) {
   callback(null, this.position);
 };
 
+/**
+ * Moves the read/write head to a new location.
+ *
+ * There are 3 signatures for this method:
+ *
+ * (callback)
+ * (position, callback)
+ * (position, seekLocation, callback)
+ *
+ * @param position
+ * @param seekLocation {number} Seek mode. Use one of the ff constants -
+ *     {@link GridStore#IO_SEEK_SET}, {@link GridStore#IO_SEEK_CUR} or
+ *     {@link GridStore#IO_SEEK_END}. Defaults to {@link GridStore#IO_SEEK_SET}
+ *     when not specified.
+ * @param callback {function(*, GridStore)} This will be called after executing
+ *     this method. The first parameter will contain null and the second one
+ *     will contain a reference to this object.
+ *
+ * @see GridStore#IO_SEEK_SET
+ * @see GridStore#IO_SEEK_CUR
+ * @see GridStore#IO_SEEK_END
+ */
 GridStore.prototype.seek = function(position, seekLocation, callback) {
   var self = this;
 
@@ -395,10 +635,21 @@ GridStore.prototype.seek = function(position, seekLocation, callback) {
   }
 };
 
+/**
+ * @return {boolean} True if the read/write head is at the end of this file.
+ */
 GridStore.prototype.eof = function() {
   return this.position == this.length ? true : false;
 };
 
+/**
+ * Retrieves a single character from this file.
+ *
+ * @param callback {function(*, ?string)} This gets called after this method is
+ *     executed. Passes null to the first parameter and the character read to
+ *     the second or null to the second if the read/write head is at the end of
+ *     the file.
+ */
 GridStore.prototype.getc = function(callback) {
   var self = this;
 
@@ -416,17 +667,60 @@ GridStore.prototype.getc = function(callback) {
   }
 };
 
+/**
+ * Writes a string to the file with a newline character appended at the end if
+ * the given string does not have one.
+ *
+ * @param string {string} The string to write.
+ * @param callback {function(*, GridStore)} This will be called after executing
+ *     this method. The first parameter will contain null and the second one
+ *     will contain a reference to this object.
+ *
+ * @see GridStore#write
+ * @see GridStore#writeFile
+ */
 GridStore.prototype.puts = function(string, callback) {
   var finalString = string.match(/\n$/) == null ? string + "\n" : string;
   this.write(finalString, callback);
 };
 
+/**
+ * The collection to be used for holding the files and chunks collection.
+ * @constant
+ */
 GridStore.DEFAULT_ROOT_COLLECTION = 'fs';
+/**
+ * Default file mime type
+ * @constant
+ */
 GridStore.DEFAULT_CONTENT_TYPE = 'text/plain';
+/**
+ * Seek mode where the given length is absolute.
+ * @constant
+ */
 GridStore.IO_SEEK_SET = 0;
+/**
+ * Seek mode where the given length is an offset to the current read/write head.
+ * @constant
+ */
 GridStore.IO_SEEK_CUR = 1;
+/**
+ * Seek mode where the given length is an offset to the end of the file.
+ * @constant
+ */
 GridStore.IO_SEEK_END = 2;
 
+/**
+ * Checks if a file exists in the database.
+ *
+ * @param db {Db} The database to query.
+ * @param name {string} The name of the file to look for.
+ * @param rootCollection {string=} opt_argument The root collection that holds the files
+ *     and chunks collection. Defaults to {@link GridStore.DEFAULT_ROOT_COLLECTION}
+ * @param callback {function(*, boolean)} This will be called after this method
+ *     executes. Passes null to the first and passes true to the second if the
+ *     file exists and false otherwise.
+ */
 GridStore.exist = function(db, name, rootCollection, callback) {
   var args = Array.prototype.slice.call(arguments, 2);
   callback = args.pop();
@@ -442,6 +736,16 @@ GridStore.exist = function(db, name, rootCollection, callback) {
   });
 };
 
+/**
+ * Gets the list of files stored in the GridFS.
+ *
+ * @param db {Db} The database to query.
+ * @param rootCollection {string=} opt_argument The root collection that holds the files
+ *     and chunks collection. Defaults to {@link GridStore.DEFAULT_ROOT_COLLECTION}
+ * @param callback {function(*, array<string>)} This will be called after this method
+ *     executes. Passes null to the first and passes an array of strings containing
+ *     the names of the files.
+ */
 GridStore.list = function(db, rootCollection, callback) {
   var args = Array.prototype.slice.call(arguments, 1);
   callback = args.pop();
@@ -462,6 +766,33 @@ GridStore.list = function(db, rootCollection, callback) {
   });
 };
 
+/**
+ * Reads the contents of a file.
+ *
+ * This method has the following signatures
+ *
+ * (db, name, callback)
+ * (db, name, length, callback)
+ * (db, name, length, offset, callback)
+ * (db, name, length, offset, options, callback)
+ *
+ * @param db {Db} The database to query.
+ * @param name {string} The name of the file
+ * @param length {number=} opt_argument The size of data to read.
+ * @param offset {number=} opt_argument The offset from the head of the file of
+ *     which to start reading from.
+ * @param options {object=} opt_argument The options for the file.
+ * @param callback {function(?Error|string, ?string)} This will be called after
+ *     this method executes. A string with an error message will be passed to
+ *     the first parameter when the length and offset combination exceeds the
+ *     length of the file while an Error object will be passed if other forms
+ *     of error occured, otherwise, a string is passed. The second parameter
+ *     will contain the data read if successful or null if an error occured.
+ *
+ * @see GridStore#read
+ * @see GridStore#readlines
+ * @see GridStore for how to pass the options
+ */
 GridStore.read = function(db, name, length, offset, options, callback) {
   var args = Array.prototype.slice.call(arguments, 2);
   callback = args.pop();
@@ -489,6 +820,23 @@ GridStore.read = function(db, name, length, offset, options, callback) {
   });
 };
 
+/**
+ * Reads the data of this file.
+ *
+ * @param db {Db} The database to query.
+ * @param name {string} The name of the file.
+ * @param separator {string=null} opt_argument The character to be recognized as
+ *     the newline separator.
+ * @param options {object=} opt_argument
+ * @param callback {function(*, Array<string>)} This will be called after this
+ *     method is executed. The first parameter will be null and the second
+ *     parameter will contain an array of strings representing the entire data,
+ *     each element representing a line including the separator character.
+ * 
+ * @see GridStore#read
+ * @see GridStore#readlines
+ * @see GridStore for how to pass the options
+ */
 GridStore.readlines = function(db, name, separator, options, callback) {
   var args = Array.prototype.slice.call(arguments, 2);
   callback = args.pop();
@@ -503,6 +851,21 @@ GridStore.readlines = function(db, name, separator, options, callback) {
   });
 };
 
+/**
+ * Deletes the chunks and metadata information of a file from GridFS.
+ *
+ * @param db {Db} The database to interact with.
+ * @param names {string|Array<string>} The names of the files to delete.
+ * @param options {object=} opt_argument The options for the files.
+ * @callback {function(?Error, GridStore)} This will be called after this method
+ *     is executed. The first parameter will contain an Error object if an error
+ *     occured or null otherwise. The second parameter will contain a reference
+ *     to this object.
+ *
+ * @see GridStore#deleteChunks
+ * @see GridStore#rewind
+ * @see GridStore for how to pass the options
+ */
 GridStore.unlink = function(db, names, options, callback) {
   var self = this;
   var args = Array.prototype.slice.call(arguments, 2);


### PR DESCRIPTION
I still have to talk with ChirstKV on what needs to be done. He seems to be pretty busy these past few days (and local time difference - He's from Barcelona) but I managed to have an appointment to have a chat with him today. So I documented the gridfs module for the mean time.

For the documentation, I try to follow Google's style guide here:
http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml

And here are also some notes regarding this commit:
gridstore.js:
line 60: I was not able to have this comment show up on the jsdoc output. It seems to disregard comments inside a function body. Do you know how to get around this?
line 165: I am not sure what the type is for the file parameter on writefile as there is no clear documentation on fs.read/fstat in the node.js website other than it appears to be a file descriptor.
line 796: There can actually be return values for this method (only on certain cases!) but I chose not to document them as I believe the author did not intend this method to have one. And it will give users crazy ideas.

Thanks!
